### PR TITLE
gsutil nightmare

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,8 +58,6 @@ deploy-preview:
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
-    - gsutil setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=86400" "gs://preview.devopsish.com/***/*.html"
     - gsutil setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.css"
     - gsutil setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.js"
     - gsutil setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.png"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,11 +52,12 @@ deploy-preview:
     url: https://preview.${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
+    - find ./ -type f \( -iname \*.html -o -iname \*.css -o -iname \*.js -o -iname \*.txt -o -iname \*.svg -o -iname \*.xml -o -iname \*.json -o -iname \*.yml -o -iname \*.yaml -o -iname \*.toml -o -iname \*.png -o -iname \*.jpg\) | xargs gzip -9 *
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml,png,jpg -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
     - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,14 +57,14 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml,png,jpg -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html.gz"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css.gz"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js.gz"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png.gz"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg.gz"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf.gz"
     - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,13 +58,13 @@ deploy-preview:
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.css"
-    - gsutil setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.js"
-    - gsutil setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.png"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpg"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpeg"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpeg"
-    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/***"
+    - gsutil setmeta -m -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
+    - gsutil setmeta -m -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
+    - gsutil setmeta -m -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
+    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
+    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil setmeta -m -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=128" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -h "Cache-Control:public, max-age=2678400" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -h "Cache-Control:public, max-age=2678400" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,13 +58,11 @@ deploy-preview:
   script:
     - gsutil -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil -m setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
-    - gsutil -m setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
-    - gsutil -m setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
-    - gsutil -m setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
-    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
-    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
-    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
     - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf"
     - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m -h "Content-Encoding:gzip, br" rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gsutil -m setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
     - gsutil -m setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
@@ -65,6 +65,7 @@ deploy-preview:
     - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
     - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
     - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf"
     - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:deflate, gzip, br" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:deflate, gzip" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ build-preview:
     expire_in: 30m
   image: registry.gitlab.com/pages/hugo:latest
   before_script:
+    - apk update
+    - apk add git
     - rm -rf public || exit 0
     - git submodule sync --recursive
     - git submodule update --init --recursive
@@ -35,8 +37,9 @@ build-prod:
     expire_in: 30m
   image: registry.gitlab.com/pages/hugo:latest
   before_script:
-    - rm -rf public || exit 0
+    - apk update
     - apk add git
+    - rm -rf public || exit 0
     - git submodule sync --recursive
     - git submodule update --init --recursive
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip, br, deflate, compress" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=128" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -a public-read -d -r public -j *.html,*.css,*.js gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/*
+    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -U -r -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,9 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -h "Cache-Control: public max-age=2678400" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -h "Cache-Control:public, max-age=2678400" \
+       -a public-read -m rsync -r public -d \
+       gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -a public-read -r public -j *.html -j *.css -j *.js -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -a public-read -r public -j .html -j .css -j .js -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,8 @@ build-preview:
     expire_in: 30m
   image: registry.gitlab.com/pages/hugo:latest
   before_script:
-    - apk update
-    - apk add git
+    - apk --no-cache update
+    - apk --no-cache add git
     - rm -rf public || exit 0
     - git submodule sync --recursive
     - git submodule update --init --recursive
@@ -37,8 +37,8 @@ build-prod:
     expire_in: 30m
   image: registry.gitlab.com/pages/hugo:latest
   before_script:
-    - apk update
-    - apk add git
+    - apk --no-cache update
+    - apk --no-cache add git
     - rm -rf public || exit 0
     - git submodule sync --recursive
     - git submodule update --init --recursive
@@ -54,6 +54,7 @@ deploy-preview:
     url: https://preview.${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
+    - apk --no-cache update
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
@@ -71,6 +72,7 @@ deploy-prod:
     url: https://${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
+    - apk --no-cache update
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -J -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,8 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_process_count=16" -o "GSUtil:parallel_thread_count=1" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" setmeta -h "Content-Encoding:gzip" -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,13 +58,13 @@ deploy-preview:
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil setmeta -m -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
-    - gsutil setmeta -m -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
-    - gsutil setmeta -m -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
-    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
-    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
-    - gsutil setmeta -m -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
-    - gsutil setmeta -m -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
+    - gsutil -m setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
+    - gsutil -m setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
+    - gsutil -m setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"
+    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg"
+    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil -m setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpeg"
+    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ build-preview:
     paths:
       - public
     expire_in: 30m
-  image: quay.io/chrisshort/hugo:latest
+  image: registry.gitlab.com/pages/hugo:latest
   before_script:
     - rm -rf public || exit 0
     - git submodule sync --recursive
@@ -51,20 +51,12 @@ deploy-preview:
     url: https://preview.${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
-    - find ./ -type f \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.txt' -o -iname '*.svg' -o -iname '*.xml' -o -iname '*.json' -o -iname '*.yml' -o -iname '*.yaml' -o -iname '*.toml' -o -iname '*.png' -o -iname '*.jpg' -o -iname '*.gif' \) -exec gzip -9 '{}' \;
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-#    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html.gz"
-#    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css.gz"
-#    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js.gz"
-#    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png.gz"
-#   - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg.gz"
-#   - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf.gz"
-#   - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -r -h "Content-Encoding:gzip, br, deflate, compress|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=16" -m setmeta -r -h "Content-Encoding:gzip, br, deflate, compress|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,8 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:gzip" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=4" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=4" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -h "Cache-Control:public, max-age=2678400" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -J -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,8 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=16" -m setmeta -r -h "Content-Encoding:gzip, br, deflate, compress|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip, br, deflate, compress" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ deploy-preview:
     url: https://preview.${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
-    - find ./ -type f \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.txt' -o -iname '*.svg' -o -iname '*.xml' -o -iname '*.json' -o -iname '*.yml' -o -iname '*.yaml' -o -iname '*.toml' -o -iname '*.png' -o -iname '*.jpg' \) -exec gzip -9 '{}' \;
+    - find ./ -type f \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.txt' -o -iname '*.svg' -o -iname '*.xml' -o -iname '*.json' -o -iname '*.yml' -o -iname '*.yaml' -o -iname '*.toml' -o -iname '*.png' -o -iname '*.jpg' -o -iname '*.gif' \) -exec gzip -9 '{}' \;
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=4" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=4" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
     - gsutil -o "GSUtil:parallel_thread_count=4" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,9 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r \
+        -h "Content-Encoding:gzip" \
+        gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ deploy-preview:
     url: https://preview.${CI_PROJECT_NAME}
   image: google/cloud-sdk:alpine
   before_script:
-    - find ./ -type f \( -iname \*.html -o -iname \*.css -o -iname \*.js -o -iname \*.txt -o -iname \*.svg -o -iname \*.xml -o -iname \*.json -o -iname \*.yml -o -iname \*.yaml -o -iname \*.toml -o -iname \*.png -o -iname \*.jpg\) | xargs gzip -9 *
+    - find ./ -type f \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.txt' -o -iname '*.svg' -o -iname '*.xml' -o -iname '*.json' -o -iname '*.yml' -o -iname '*.yaml' -o -iname '*.toml' -o -iname '*.png' -o -iname '*.jpg' \) -exec gzip -9 '{}' \;
     - echo -n ${GCS_TOKEN} | base64 -d > ${GCS_TOKEN_FILE}
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,9 @@ build-preview:
     paths:
       - public
     expire_in: 30m
-  image: registry.gitlab.com/pages/hugo:latest
+  image: quay.io/chrisshort/hugo:latest
   before_script:
     - rm -rf public || exit 0
-    - apk add git
     - git submodule sync --recursive
     - git submodule update --init --recursive
   script:
@@ -59,13 +58,13 @@ deploy-preview:
   script:
     - gsutil -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf.gz"
-    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
+#    - gsutil -m setmeta -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html.gz"
+#    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css.gz"
+#    - gsutil -m setmeta -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js.gz"
+#    - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png.gz"
+#   - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.jpg.gz"
+#   - gsutil -m setmeta -h "Cache-Control:public, max-age=31536000" "gs://preview.devopsish.com/**/*.pdf.gz"
+#   - gsutil -m setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/*
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -a public-read -d -r public -j *.html -j *.css -j *.js gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -a public-read -r public -j *.html -j *.css -j *.js -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -C -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_process_count=16" -o "GSUtil:parallel_thread_count=1" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
     - gsutil -o "GSUtil:parallel_thread_count=64" setmeta -h "Content-Encoding:gzip" -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=64" setmeta -h "Content-Encoding:gzip" -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,9 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -h "Cache-Control:public, max-age=2678400" \
-       -m rsync -a public-read -r public -d \
-       gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -h "Cache-Control:public, max-age=2678400" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -a public-read -Z -d -r public gs://preview.${CI_PROJECT_NAME}/
     - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -a public-read -r public -j .html -j .css -j .js -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -h "Cache-Control: public max-age=2678400" -m rsync -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:deflate, gzip" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:gzip" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,9 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m -h "Content-Encoding:gzip, br" rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
+    - gsutil -m setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=14400" "gs://preview.devopsish.com/**/*.html"
     - gsutil -m setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.css"
     - gsutil -m setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/**/*.js"
     - gsutil -m setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/**/*.png"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -U -r -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -U -r -h "Content-Encoding:gzip|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -h "Cache-Control:public, max-age=2678400" \
-       -a public-read -m rsync -r public -d \
+       -m rsync -a public-read -r public -d \
        gs://preview.${CI_PROJECT_NAME}/
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -U -r -h "Content-Encoding:gzip|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -r -h "Content-Encoding:gzip, br, deflate, compress|Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=8" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,8 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip" gs://preview.${CI_PROJECT_NAME}/
+  after_script:
+    - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,6 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -m rsync -a public-read -d -r public -j *.html,*.css,*.js gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -m rsync -a public-read -d -r public -j *.html -j *.css -j *.js gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,9 +57,7 @@ deploy-preview:
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
     - gsutil -o "GSUtil:parallel_thread_count=64" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r \
-        -h "Content-Encoding:gzip" \
-        gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=64" -m setmeta -r -h "Content-Encoding:gzip" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,8 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=4" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
-    - gsutil -o "GSUtil:parallel_thread_count=4" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -C -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=1" -h "Cache-Control:public, max-age=2678400" -h "Accept-Encoding:deflate, gzip, br" -m cp -a public-read -r public -d gs://preview.${CI_PROJECT_NAME}/
   except:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,15 +58,15 @@ deploy-preview:
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
-    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/static/**/*"
-    - gsutil setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=86400" -r "gs://preview.devopsish.com/***/*.html"
-    - gsutil setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" -r "gs://preview.devopsish.com/***/*.css"
-    - gsutil setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" -r "gs://preview.devopsish.com/***/*.js"
-    - gsutil setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.png"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpg"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpeg"
-    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpeg"
-    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/static/**/*"
+    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/**/*"
+    - gsutil setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=86400" "gs://preview.devopsish.com/***/*.html"
+    - gsutil setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.css"
+    - gsutil setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" "gs://preview.devopsish.com/***/*.js"
+    - gsutil setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.png"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpg"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpeg"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/***/*.jpeg"
+    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" "gs://preview.devopsish.com/static/***"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,15 @@ deploy-preview:
   script:
     - gsutil -o "GSUtil:parallel_thread_count=16" -h "Content-Encoding:gzip" -m rsync -j html,css,js,txt,svg,xml,json,yml,yaml,toml -a public-read -d -r public gs://preview.${CI_PROJECT_NAME}/
   after_script:
+    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/static/**/*"
+    - gsutil setmeta -h "Content-Type:text/html" -h "Cache-Control:public, max-age=86400" -r "gs://preview.devopsish.com/***/*.html"
+    - gsutil setmeta -h "Content-Type:text/css" -h "Cache-Control:public, max-age=604800" -r "gs://preview.devopsish.com/***/*.css"
+    - gsutil setmeta -h "Content-Type:application/javascript" -h "Cache-Control:public, max-age=604800" -r "gs://preview.devopsish.com/***/*.js"
+    - gsutil setmeta -h "Content-Type:image/png" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.png"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpg"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpeg"
+    - gsutil setmeta -h "Content-Type:image/jpeg" -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/***/*.jpeg"
+    - gsutil setmeta -h "Cache-Control:public, max-age=2721600" -r "gs://preview.devopsish.com/static/**/*"
     - gcloud compute url-maps invalidate-cdn-cache devopsish-lb --path "/*" --host preview.${CI_PROJECT_NAME} --async
   except:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ deploy-preview:
     - gcloud config set project ${GCS_PROJECT}
     - gcloud auth activate-service-account --key-file ${GCS_TOKEN_FILE}
   script:
-    - gsutil -o "GSUtil:parallel_thread_count=8" -m rsync -a public-read -Z -d -r public gs://preview.${CI_PROJECT_NAME}/
+    - gsutil -o "GSUtil:parallel_thread_count=16" -m rsync -a public-read -J -d -r public gs://preview.${CI_PROJECT_NAME}/
     - gsutil -o "GSUtil:parallel_thread_count=8" setmeta -h "Content-Disposition" -h "Content-Encoding:gzip" -h "Cache-Control:public, max-age=2678400" gs://preview.${CI_PROJECT_NAME}/
   except:
     - master


### PR DESCRIPTION
I was trying to get Google Cloud CDN and Storage to place nice with literally any headers or redirects and it was not a pleasant experience.

Current idea is to drop a tiny sliver of compute with a reverse proxy as a backend service for the load balancer. This will allow for HTTP headers, gzip, redirects, etc. without all the entanglements of gsutil and Google's whims.