### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://devopsish.com"
 title = "DevOps'ish"
 author = "Chris Short"
 theme = "paper"


### PR DESCRIPTION
Google Search Console alerted to a malformed sitemap. Hugo is generating links without https://devopsish.com as the baseURL.