### PR TITLE
Here's the deal

### DIFF
--- a/content/post/070/index.md
+++ b/content/post/070/index.md
@@ -3,10 +3,10 @@
 author = "Chris Short"
 categories = ["Weekly", "Newsletter", "DevOps News", "Cloud Native News", "GitOps News", "2018"]
 date = 2018-04-08T07:00:00Z
-description = ""
+description = "Not the Postmortem We Wanted to Run"
 draft = false
 slug = "070"
-tags = ["devops", "cloud native", "open source", "youtube shooting", "devsecops", "kubernetes", "diveristy", "containers", "Docker"]
+tags = ["Kubernetes", "DevOps", "open source", "cloud", "cloud native", "security", "containers", "people", "work", "DevOpsDays", "Google", "application", "postmortem", "Arm", "Docker", "Mac", "diversity", "deploy", "shooting", "practice", "performance", "Apple", "compute", "data", "Atlanta", "infrastructure", "ChefConf", "Toronto", "code", "AWS", "DevSecOps", "GitHub", "git", "Intel"]
 title = "070: Not the Postmortem We Wanted to Run"
 image ="https://shortcdn.com/file/devopsish/070.jpg"
 imagealt = "Not the Postmortem We Wanted to Run"


### PR DESCRIPTION
I use an app called Integrity to check for broken links. Everything pointing to page 070 fails for some reason. Integrity reports the links as soft 404s.

There are no redirects causing any weirdness to my knowledge.

I updated the description and tags thinking if I'm going to add a description I might as well run it through the keyword checks too.